### PR TITLE
Removes unneccessary quotes and equals signs

### DIFF
--- a/crp.py
+++ b/crp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 '''
 Requires EXIFTOOL
 '''
@@ -383,7 +383,7 @@ def find_csv(source_directory):
 
 def main():
     # Create args object which holds the command line arguments.
-    print('\n- California Revealed Project Dublin Core Metadata Generator - v0.6')
+    print('\n- California Revealed Project Dublin Core Metadata Generator - v0.7')
     args = parse_args()
     # Declare appropriate XML namespaces.
     dc_namespace = 'http://purl.org/dc/elements/1.1/'

--- a/crp.py
+++ b/crp.py
@@ -411,10 +411,16 @@ def main():
         if os.path.isdir(full_folder_path):
             # Loop through all records in the CSV.
             for csv_record in csv_data:
+
                 # Only proceed if the Object Identifier in the CSV record matches
                 # the folder name that is currently being analysed.
                 package_info = analyse_folder(full_folder_path)
                 if csv_record['Object Identifier'] == folder:
+                    for values in csv_record:
+                        # Check if any CSV values have unnecessary quotes and equals signs.
+                        if '=' in csv_record[values]:
+                            if csv_record[values][0:2] == '=\"':
+                                csv_record[values] = csv_record[values][2:][:-1]
                     root_metadata_element, dublin_core_object = add_DC_metadata(
                         folder,
                         dc_namespace,

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(
     license='MIT',
     install_requires=['lxml'],
     name='crp_dc',
-    version='0.6'
+    version='0.7'
 )


### PR DESCRIPTION
Some CSV exports have unnecessary quotes and equals signs that should not make their way to the XML output. This PR should fix this.
here's an example of some of these values:
```
="Unknown"
="1942~"
=""
=""
=""
="1942~"
="1922"
=""
=""
=""
="1922"
="1985"
=""
=""
=""
="1985"

```

which then become:
```

Unknown
1942~



1942~
1922



1922
1985



1985
