### PR TITLE
adds workaround to accomodate islandora CSV field error

### DIFF
--- a/crp.py
+++ b/crp.py
@@ -431,7 +431,12 @@ def main():
                         )
                         term_list.append(dc_term)
                     medium, extent_total, extent_dimensions, created = term_list
-                    extent_total.text = csv_record['Total Number of Pages']
+                    try:
+                        extent_total.text = csv_record['Total Number of Pages']
+                    except KeyError:
+                        print('- "Total Number of Pages" value is missing from CSV')
+                        print('- Using "Total Number of Reels or Tapes" instead')
+                        extent_total.text = csv_record['Total Number of Reels or Tapes']
                     medium.text = csv_record['Format']
                     extent_dimensions.text = csv_record['Extent (dimensions)']
                     # why is there an equals character and quotes in the CSV?


### PR DESCRIPTION
Some CSV exports from Islandora for non-AV material use the 'Total Number of Reels or Tapes' fieldname, when it should use 'Total Number of Pages'. A current workaround is to manually change the CSV. This may not be necessary as the issue could just be fixed in Islandora, but it was a quick fix. 
This PR will:
* Check for the 'Total Number of Pages' value
* If this is not present in the CSV, it will use 'Total Number of Reels or Tapes' instead.
* The user will be informed that this has occured.

Terminal output:
```
c$ ./crp.py   -i '/home/kierannnn/sample_objects_for_kieran/cmv'  -csv '/home/kierannn/Downloads/cfcpl_export_18junne2018(2).csv'  

- California Revealed Project Dublin Core Metadata Generator - v0.6
- The following folder: /home/kierannnn/sample_objects_for_kieran/cmv will be analysed against this CSV file: /home/kierannnn/Downloads/cfcpl_export_18junne2018(2).csv
- Found cfcpl_000045, processing...
- "Total Number of Pages" value is missing from CSV
- Using "Total Number of Reels or Tapes" instead
- Finished

```