### PR TITLE
Minor tweaks to documentation and provenance info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# Table of Contents
+- [crp.py](#crppy)
+    - [about](#about)
+    - [dependencies](#dependencies)
+    - [installation](#installation)
+        - [python](#python)
+        - [installing pip](#installing-pip)
+        - [installing ExifTool](#installing-exiftool)
+        - [installing the crp_dc script](#installing-the-crp_dc-script)
+    - [upgrading](#upgrading)
+    - [usage](#usage)
+
 crp_dc
 ========
 Transforms legacy CSV metadata into Dublin Core XML, and extracting technical metadata of digitised files supplied by vendors for the California Revealed Project.
@@ -8,13 +20,14 @@ Transforms legacy CSV metadata into Dublin Core XML, and extracting technical me
 
 `crp.py` transforms a very specifically formatted CSV file into Dublin Core XML, while also extracting technical metadata of digitised files supplied by vendors for the California Revealed Project.
 
+---
 ### dependencies
 `crp.py` requires:
 - `exiftool`
 - `lxml`
 - `python`
 - `pip`
-
+---
 ### installation
 
 #### python
@@ -38,12 +51,14 @@ and when `homebrew` has installed, type:
 `brew install python`
 in order to install `python`.
 
+---
 #### installing pip
 
 The easiest way to install the script is via the python package manager `pip`.
 
 In order to install `pip` on OSX, enter `sudo easy_install pip` in the terminal.
 
+---
 #### installing ExifTool
 
 You may have to install `exiftool` as this is used to extract technical metadata.
@@ -52,18 +67,20 @@ If using homebrew this can be installed with:
 
 `brew install exiftool`
 
+---
 #### installing the crp_dc script
-
 Finally, you can install the script by entering
 
 `pip install crp_dc`
 
 This will also install the `lxml` python XML processing library.
 
+---
 ### upgrading
 To upgrade the script, enter:
 `pip install crp_dc -U`
 
+---
 ### usage
 The script takes two arguments:
 
@@ -80,5 +97,3 @@ An example command, that assumes that the folder (called `LTO_SHIPMENT`) that yo
 If the CSV file is located in '/Volumes/CAVPP-05/LTO_SHIPMENT', then the command would just be:
 
 `crp.py -i /Volumes/CAVPP-05/LTO_SHIPMENT`
-
-

--- a/README.md
+++ b/README.md
@@ -16,15 +16,43 @@ Transforms legacy CSV metadata into Dublin Core XML, and extracting technical me
 - `pip`
 
 ### installation
-Most likely `python` is already installed on OSX. The easiest way to install the scripts is via the python package manager `pip`.
+
+#### python
+
+`python` is installed by default on OSX. You can verify that it is installed by typing:
+
+`python`
+
+in the terminal. You should see something like:
+```
+$ python
+Python 2.7.12 (default, Dec  4 2017, 14:50:18) 
+[GCC 5.4.0 20160609] on darwin
+Type "help", "copyright", "credits" or "license" for more information.
+```
+
+if `python` is installed. If `python` is not installed, then the easiest method of doing so is with `homebrew`.
+In order to install `homebrew`, follow the instructions at https://brew.sh/
+
+and when `homebrew` has installed, type:
+`brew install python`
+in order to install `python`.
+
+#### installing pip
+
+The easiest way to install the script is via the python package manager `pip`.
 
 In order to install `pip` on OSX, enter `sudo easy_install pip` in the terminal.
+
+#### installing ExifTool
 
 You may have to install `exiftool` as this is used to extract technical metadata.
 
 If using homebrew this can be installed with:
 
 `brew install exiftool`
+
+#### installing the crp_dc script
 
 Finally, you can install the script by entering
 

--- a/crp.py
+++ b/crp.py
@@ -91,7 +91,7 @@ def add_DC_metadata(folder, dc_namespace, xsi_namespace, csv_record):
     dc_rights_country.attrib["type"] = 'Country of Creation'
     dc_rights.text = csv_record['Copyright Statement']
     dc_rights_country.text = csv_record['Country of Creation']
-    dc_crp_provenance.text = 'California Revealed Project'
+    dc_crp_provenance.text = 'California Revealed'
     dc_provenance.text = csv_record['Institution']
     dc_format.text = csv_record['Generation']
     dc_title.text = csv_record['Main or Supplied Title']


### PR DESCRIPTION
So this PR:
* changes the provenance info from `California Revealed Project` to `California Revealed`.
* It also adds `python` installation instructions, should python not be installed on OSX.
* It also adds a table of contents so that the readme looks prettier - a preview can be seen here: https://gist.github.com/kieranjol/354565e43501bd8ce13ef540e6a7d3d6

