### PR TITLE
README - use sudo for pip - thx Pamela

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If using homebrew this can be installed with:
 #### installing the crp_dc script
 Finally, you can install the script by entering
 
-`pip install crp_dc`
+`sudo pip install crp_dc`
 
 This will also install the `lxml` python XML processing library.
 


### PR DESCRIPTION
Uses sudo for pip as there's inconsistencies and errors depending on the python installation.