### PR TITLE
General fixes

### DIFF
--- a/crp.py
+++ b/crp.py
@@ -140,7 +140,7 @@ def add_DC_metadata(folder, dc_namespace, xsi_namespace, csv_record):
     dc_description_issue.attrib["type"] = 'serial issue'
     dc_coverage.text = csv_record['Publication Location']
     dc_coverage.attrib["type"] = 'publication location'
-    return root_metadata_element, dublin_core_object, dc_creator
+    return root_metadata_element, dublin_core_object, dc_creator, dc_title
 
 
 def create_dc_element(index, parent, dc_element, dublin_core_namespace):
@@ -473,7 +473,7 @@ def main():
                         if '=' in csv_record[values]:
                             if csv_record[values][0:2] == '=\"':
                                 csv_record[values] = csv_record[values][2:][:-1]
-                    root_metadata_element, dublin_core_object, creator = add_DC_metadata(
+                    root_metadata_element, dublin_core_object, creator, title = add_DC_metadata(
                         folder,
                         dc_namespace,
                         xsi_namespace,
@@ -491,10 +491,17 @@ def main():
                     extent_dimensions, extent_total, medium = term_list
                     # Quick and dirty hack to move the created element below the creator element :(
                     creator_index = creator.getparent().index(creator)
+                    title_index = title.getparent().index(title)
                     created = create_dc_element(
                             index=creator_index + 1,
                             parent=root_metadata_element,
                             dc_element='created',
+                            dublin_core_namespace=dc_terms_namespace
+                        )
+                    alternative_title = create_dc_element(
+                            index=title_index + 1,
+                            parent=root_metadata_element,
+                            dc_element='alternative',
                             dublin_core_namespace=dc_terms_namespace
                         )
                     # end of quick/dirty hack :(((
@@ -513,6 +520,7 @@ def main():
                     extent_dimensions.text = csv_record['Extent (dimensions)']
                     # why is there an equals character and quotes in the CSV?
                     created.text = csv_record['Date Created']
+                    alternative_title.text = csv_record['Additional Title']
                     (objectIdentifier,
                      callNumber,
                      projectIdentifier,

--- a/crp.py
+++ b/crp.py
@@ -324,7 +324,8 @@ def create_instantiations(AssetPart_element, instantation_counter, generation):
             dc_element=elements,
         )
         instantiation_element_list.append(element)
-        counter += 1
+        if not generation == 'Print':
+            counter += 1
     return instantiation_element_list
 
 
@@ -408,7 +409,8 @@ def techncial_metadata(package_info, AssetPart_element, csv_record):
                     digitizerModel.text = str(exiftool_json["Model"])
                 except KeyError:
                     digitizerModel.getparent().remove(digitizerModel)
-        instantiation_counter += 1
+        if not sub_item == 'Print':
+            instantiation_counter += 1
 
 
 def find_csv(source_directory):

--- a/crp.py
+++ b/crp.py
@@ -463,7 +463,7 @@ def find_csv(source_directory):
 
 def main():
     # Create args object which holds the command line arguments.
-    print('\n- California Revealed Project Dublin Core Metadata Generator - v0.17')
+    print('\n- California Revealed Project Dublin Core Metadata Generator - v0.18')
     args = parse_args()
     # Declare appropriate XML namespaces.
     dc_namespace = 'http://purl.org/dc/elements/1.1/'

--- a/crp.py
+++ b/crp.py
@@ -488,7 +488,7 @@ def main():
                             dublin_core_namespace=dc_terms_namespace
                         )
                         term_list.append(dc_term)
-                    extent_total, extent_dimensions, medium = term_list
+                    extent_dimensions, extent_total, medium = term_list
                     # Quick and dirty hack to move the created element below the creator element :(
                     creator_index = creator.getparent().index(creator)
                     created = create_dc_element(

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(
     license='MIT',
     install_requires=['lxml'],
     name='crp_dc',
-    version='0.17'
+    version='0.18'
 )


### PR DESCRIPTION
This addresses some of the errors that @pamelajean found:
* The `extents` will now display in the correct order.
* The additional/alternative title will display
* The PDF will no longer be counted as a page as a result, knock out the correct ordering of pages by one
* Alternate angle scans, for example: 'kieran_001.tif' is a sealed, folded photo, 'kieran_001_01.tif' will all have the same page number. These scans previously had a different page number that was causing the page order to go off-kilter.